### PR TITLE
Bugfix For Empty Queue Group

### DIFF
--- a/app/presenters/rush_job_mongoid/queue_groups_presenter.rb
+++ b/app/presenters/rush_job_mongoid/queue_groups_presenter.rb
@@ -19,7 +19,7 @@ module RushJobMongoid
     private
 
     def queue_groups_from_presener
-      @rush_job_queue_groups[(@queue_groups_presenter.page - 1) * 10, 10]
+      @rush_job_queue_groups[(@queue_groups_presenter.page - 1) * 10, 10] || []
     end
   end
 end

--- a/test/system/rush_job_mongoid/dashboard_pagination_test.rb
+++ b/test/system/rush_job_mongoid/dashboard_pagination_test.rb
@@ -110,6 +110,11 @@ module RushJobMongoid
       end
 
       assert_text 'Queue 10'
+
+      RushJob.delete_all
+      click_button 'Reload'
+
+      assert_no_text 'Queue 10'
     end
   end
 end


### PR DESCRIPTION
This change handles the situation where the page of queue groups doesn't exist.